### PR TITLE
Add output sanitization

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,6 +18,7 @@ jobs:
           ignored,
           import,
           nth-child,
+          sanitize,
           selector
         ]
     steps:

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ An options object can be passed as the second argument to `cssToHtml()` to custo
 | `fill`       | `fill`       * | Fill the DOM with duplicate elements up to the desired location. Eg: <br/> `span#fourth:nth-child(4) {}` <br/> Will become: <br/> `<span></span><span></span><span></span><span id="fourth"></span>`. |
 |              | `no-fill`      | Don't fill. Eg: <br/> `span#fourth:nth-child(4) {}` <br/> Will become: <br/> `<span id="fourth"></span>`. |
 | `imports`    | `include`      | Fetch imported stylesheets and include them in the HTML generation process. |
-|              | `style-only` * | Ignore `@import` rules. |
+|              | `style-only` * | Ignore `@import` rules when generating HTML. |
 | `mergeNth`   | `merge`      * | Elements generated from `:nth-` selectors will be merged with any similar element occupying the desired location. |
 |              | `no-merge`     | These elements will not be merged. |
+| `sanitize`   | `all` *        | Sanitize the generated HTML using DOMPurify. |
+|              | `imports`      | Only sanitize HTML generated from imported stylesheets. |
+|              | `off`          | Don't sanitize the generated HTML. |

--- a/README.md
+++ b/README.md
@@ -76,6 +76,6 @@ An options object can be passed as the second argument to `cssToHtml()` to custo
 |              | `style-only` * | Ignore `@import` rules when generating HTML. |
 | `mergeNth`   | `merge`      * | Elements generated from `:nth-` selectors will be merged with any similar element occupying the desired location. |
 |              | `no-merge`     | These elements will not be merged. |
-| `sanitize`   | `all` *        | Sanitize the generated HTML using DOMPurify. |
-|              | `imports`      | Only sanitize HTML generated from imported stylesheets. |
+| `sanitize`   | `all`        * | Sanitize the generated HTML using [DOMPurify](https://github.com/cure53/DOMPurify). |
+|              | `imports`      | Only sanitize the HTML generated from imported stylesheets. |
 |              | `off`          | Don't sanitize the generated HTML. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
 			"version": "0.5.0",
 			"license": "MIT",
 			"dependencies": {
-				"css-selector-parser": "^2.3.2"
+				"css-selector-parser": "^2.3.2",
+				"dompurify": "^3.1.2"
 			},
 			"devDependencies": {
-				"@playwright/test": "^1.35.1"
+				"@playwright/test": "^1.35.1",
+				"@types/dompurify": "^3.0.5"
 			}
 		},
 		"node_modules/@playwright/test": {
@@ -34,10 +36,25 @@
 				"fsevents": "2.3.2"
 			}
 		},
+		"node_modules/@types/dompurify": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+			"integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+			"dev": true,
+			"dependencies": {
+				"@types/trusted-types": "*"
+			}
+		},
 		"node_modules/@types/node": {
 			"version": "20.4.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.0.tgz",
 			"integrity": "sha512-jfT7iTf/4kOQ9S7CHV9BIyRaQqHu67mOjsIQBC3BKZvzvUB6zLxEwJ6sBE3ozcvP8kF6Uk5PXN0Q+c0dfhGX0g==",
+			"dev": true
+		},
+		"node_modules/@types/trusted-types": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
 			"dev": true
 		},
 		"node_modules/css-selector-parser": {
@@ -54,6 +71,11 @@
 					"url": "https://patreon.com/mdevils"
 				}
 			]
+		},
+		"node_modules/dompurify": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.2.tgz",
+			"integrity": "sha512-hLGGBI1tw5N8qTELr3blKjAML/LY4ANxksbS612UiJyDfyf/2D092Pvm+S7pmeTGJRqvlJkFzBoHBQKgQlOQVg=="
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.2",
@@ -94,16 +116,36 @@
 				"playwright-core": "1.35.1"
 			}
 		},
+		"@types/dompurify": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+			"integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+			"dev": true,
+			"requires": {
+				"@types/trusted-types": "*"
+			}
+		},
 		"@types/node": {
 			"version": "20.4.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.0.tgz",
 			"integrity": "sha512-jfT7iTf/4kOQ9S7CHV9BIyRaQqHu67mOjsIQBC3BKZvzvUB6zLxEwJ6sBE3ozcvP8kF6Uk5PXN0Q+c0dfhGX0g==",
 			"dev": true
 		},
+		"@types/trusted-types": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+			"dev": true
+		},
 		"css-selector-parser": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-2.3.2.tgz",
 			"integrity": "sha512-JjnG6/pdLJh3iqipq7kteNVtbIczsU2A1cNxb+VAiniSuNmrB/NI3us4rSCfArvlwRXYly+jZhUUfEoInSH9Qg=="
+		},
+		"dompurify": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.2.tgz",
+			"integrity": "sha512-hLGGBI1tw5N8qTELr3blKjAML/LY4ANxksbS612UiJyDfyf/2D092Pvm+S7pmeTGJRqvlJkFzBoHBQKgQlOQVg=="
 		},
 		"fsevents": {
 			"version": "2.3.2",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,11 @@
 	},
 	"homepage": "https://github.com/CSS-Canvas/CSS-to-HTML#readme",
 	"devDependencies": {
-		"@playwright/test": "^1.35.1"
+		"@playwright/test": "^1.35.1",
+		"@types/dompurify": "^3.0.5"
 	},
 	"dependencies": {
-		"css-selector-parser": "^2.3.2"
+		"css-selector-parser": "^2.3.2",
+		"dompurify": "^3.1.2"
 	}
 }

--- a/src/Descriptor.ts
+++ b/src/Descriptor.ts
@@ -1,6 +1,5 @@
 import type { AstRule } from 'css-selector-parser';
-import * as DOMPurify from 'dompurify';
-import { replaceTextNode } from './Utility.js';
+import { replaceTextNode, sanitizeElement } from './Utility.js';
 
 /**
  * Valid positioning pseudo classes.
@@ -101,7 +100,7 @@ export class Descriptor {
 
 		// Sanitize the element.
 		if (this.sanitize) {
-			this.element = DOMPurify.sanitize(this.element, { RETURN_DOM: true });
+			this.element = sanitizeElement(this.element);
 		}
 
 		// Set the content.
@@ -181,7 +180,7 @@ export class Descriptor {
 
 		// Sanitize the element.
 		if (this.sanitize) {
-			this.element = DOMPurify.sanitize(this.element, { RETURN_DOM: true });
+			this.element = sanitizeElement(this.element);
 		}
 	}
 

--- a/src/Descriptor.ts
+++ b/src/Descriptor.ts
@@ -1,4 +1,5 @@
 import type { AstRule } from 'css-selector-parser';
+import * as DOMPurify from 'dompurify';
 import { replaceTextNode } from './Utility.js';
 
 /**
@@ -55,9 +56,11 @@ export class Descriptor {
 	};
 	public invalid = false;
 	private rawContent = '';
+	private sanitize = false;
 
-	constructor (rule: AstRule, content?: string) {
+	constructor (rule: AstRule, content?: string, sanitize = false) {
 		this.rule = rule;
+		this.sanitize = sanitize;
 
 		// Create the element.
 		let tag = 'div';
@@ -94,6 +97,11 @@ export class Descriptor {
 				}
 				this.element.setAttribute(attribute.name, value);
 			}
+		}
+
+		// Sanitize the element.
+		if (this.sanitize) {
+			this.element = DOMPurify.sanitize(this.element, { RETURN_DOM: true });
 		}
 
 		// Set the content.
@@ -169,6 +177,11 @@ export class Descriptor {
 		// Use the content as inner-text for all other elements.
 		else {
 			replaceTextNode(this.element, value);
+		}
+
+		// Sanitize the element.
+		if (this.sanitize) {
+			this.element = DOMPurify.sanitize(this.element, { RETURN_DOM: true });
 		}
 	}
 

--- a/src/Descriptor.ts
+++ b/src/Descriptor.ts
@@ -44,8 +44,8 @@ function parsePositionFormula (a: number, b: number): number | false {
  * Describes an element based on pieces of a selector.
  */
 export class Descriptor {
-	public rule;
-	public element;
+	public rule: AstRule;
+	public element: HTMLElement;
 	public combinator = '';
 	public position = {
 		explicit: false,

--- a/src/Generator.ts
+++ b/src/Generator.ts
@@ -1,5 +1,6 @@
 import { createParser } from 'css-selector-parser';
 import type { AstRule } from 'css-selector-parser';
+import * as DOMPurify from 'dompurify';
 import { Descriptor } from './Descriptor.js';
 import { createCSSOM, elementsAreComparable, mergeElements } from './Utility.js';
 
@@ -179,6 +180,14 @@ export async function cssToHtml (css: CSSRuleList | string, options: Options = {
 				nestIndex++;
 			}
 		}
+	}
+
+	if (options.sanitize === 'all') {
+		const cleanHtml = DOMPurify.sanitize(output, { RETURN_DOM: true });
+		if (cleanHtml instanceof HTMLBodyElement) return cleanHtml;
+		const body = document.createElement('body');
+		body.append(cleanHtml);
+		return body;
 	}
 
 	return output;

--- a/src/Generator.ts
+++ b/src/Generator.ts
@@ -1,5 +1,5 @@
 import { createParser } from 'css-selector-parser';
-import type { AstRule } from 'css-selector-parser';
+import type { AstRule, AstSelector } from 'css-selector-parser';
 import * as DOMPurify from 'dompurify';
 import { Descriptor } from './Descriptor.js';
 import { createCSSOM, elementsAreComparable, mergeElements } from './Utility.js';
@@ -15,8 +15,8 @@ export class Options {
 const parse = createParser({ syntax: 'progressive' });
 
 class Rule {
-	rule;
-	selectorAst;
+	rule: CSSStyleRule;
+	selectorAst: AstSelector;
 
 	constructor (rule: CSSStyleRule) {
 		this.rule = rule;

--- a/src/Generator.ts
+++ b/src/Generator.ts
@@ -16,10 +16,12 @@ const parse = createParser({ syntax: 'progressive' });
 
 class Rule {
 	rule: CSSStyleRule;
+	sanitize: boolean;
 	selectorAst: AstSelector;
 
-	constructor (rule: CSSStyleRule) {
+	constructor (rule: CSSStyleRule, sanitize = false) {
 		this.rule = rule;
+		this.sanitize = sanitize;
 		this.selectorAst = parse(rule.selectorText);
 	}
 }
@@ -49,12 +51,12 @@ export async function cssToHtml (css: CSSRuleList | string, options: Options = {
 	const rules = new Array<Rule>();
 	const importSet = new Set<string>();
 	
-	async function parseRules (source: CSSRuleList, urlBase: string): Promise<void> {
+	async function parseRules (source: CSSRuleList, urlBase: string, sanitize?: boolean): Promise<void> {
 		let seenStyleRule = false;
 		for (const rule of Object.values(source!)) {
 			if (rule instanceof CSSStyleRule) {
 				seenStyleRule = true;
-				rules.push(new Rule(rule));
+				rules.push(new Rule(rule, sanitize));
 			}
 			// Fetch the content of imported stylesheets.
 			else if (rule instanceof CSSImportRule && !seenStyleRule && options.imports === 'include') {
@@ -65,7 +67,7 @@ export async function cssToHtml (css: CSSRuleList | string, options: Options = {
 					if (resource.status !== 200) throw new Error(`Response status for stylesheet "${url.href}" was ${resource.status}.`);
 					const text = await resource.text();
 					const importedRule = createCSSOM(text);
-					if (importedRule) await parseRules(importedRule, url.href);
+					if (importedRule) await parseRules(importedRule, url.href, options.sanitize === 'imports');
 				}
 			}
 		}
@@ -73,7 +75,7 @@ export async function cssToHtml (css: CSSRuleList | string, options: Options = {
 	await parseRules(styleRules, window.location.href);
 
 	// Populate the DOM.
-	for (const { rule, selectorAst } of rules) {
+	for (const { rule, sanitize, selectorAst } of rules) {
 		// Traverse each rule nest of the selector AST.
 		for (const r of selectorAst.rules) {
 			const nest = new Array<Descriptor>();
@@ -81,7 +83,7 @@ export async function cssToHtml (css: CSSRuleList | string, options: Options = {
 			// Create a descriptor for each of the nested selectors.
 			let next: AstRule | undefined = r;
 			do {
-				const descriptor = new Descriptor(next);
+				const descriptor = new Descriptor(next, undefined, sanitize);
 				if (descriptor.invalid) {
 					invalidNest = true;
 					next = undefined;

--- a/src/Generator.ts
+++ b/src/Generator.ts
@@ -1,8 +1,7 @@
 import { createParser } from 'css-selector-parser';
 import type { AstRule, AstSelector } from 'css-selector-parser';
-import * as DOMPurify from 'dompurify';
 import { Descriptor } from './Descriptor.js';
-import { createCSSOM, elementsAreComparable, mergeElements } from './Utility.js';
+import { createCSSOM, elementsAreComparable, mergeElements, sanitizeElement } from './Utility.js';
 
 export class Options {
 	duplicates?: 'preserve' | 'remove';
@@ -185,7 +184,7 @@ export async function cssToHtml (css: CSSRuleList | string, options: Options = {
 	}
 
 	if (options.sanitize !== 'off' && options.sanitize !== 'imports') {
-		const cleanHtml = DOMPurify.sanitize(output, { RETURN_DOM: true });
+		const cleanHtml = sanitizeElement(output);
 		if (cleanHtml instanceof HTMLBodyElement) return cleanHtml;
 		const body = document.createElement('body');
 		body.append(cleanHtml);

--- a/src/Generator.ts
+++ b/src/Generator.ts
@@ -8,6 +8,7 @@ export class Options {
 	fill?: 'fill' | 'no-fill';
 	imports?: 'include' | 'style-only';
 	mergeNth?: 'merge' | 'no-merge';
+	sanitize?: 'all' | 'imports' | 'off';
 }
 
 const parse = createParser({ syntax: 'progressive' });

--- a/src/Generator.ts
+++ b/src/Generator.ts
@@ -184,7 +184,7 @@ export async function cssToHtml (css: CSSRuleList | string, options: Options = {
 		}
 	}
 
-	if (options.sanitize === 'all') {
+	if (options.sanitize !== 'off' && options.sanitize !== 'imports') {
 		const cleanHtml = DOMPurify.sanitize(output, { RETURN_DOM: true });
 		if (cleanHtml instanceof HTMLBodyElement) return cleanHtml;
 		const body = document.createElement('body');

--- a/src/Utility.ts
+++ b/src/Utility.ts
@@ -90,7 +90,7 @@ export function replaceTextNode (element: HTMLElement | Element, value: string):
  */
 export function sanitizeElement (element: HTMLElement): HTMLElement {
     const sanitizedElement = DOMPurify.sanitize(element, { RETURN_DOM: true });
-    if (sanitizedElement.tagName.toLowerCase() === 'body' && element.tagName.toLowerCase() !== 'body') {
+    if (sanitizedElement instanceof HTMLBodyElement && !(element instanceof HTMLBodyElement)) {
         return sanitizedElement.firstElementChild as HTMLElement;
     }
     return sanitizedElement;

--- a/src/Utility.ts
+++ b/src/Utility.ts
@@ -1,3 +1,5 @@
+import DOMPurify from 'dompurify';
+
 /**
  * Create a CSS Object Model from a string of CSS.
  * @param css The CSS string.
@@ -79,4 +81,17 @@ export function replaceTextNode (element: HTMLElement | Element, value: string):
     } else {
         element.append(value);
     }
+}
+
+/**
+ * Sanitize a given HTML element with DOMPurify.
+ * @param element The element to sanitize.
+ * @returns A sanitized copy of the given element.
+ */
+export function sanitizeElement (element: HTMLElement): HTMLElement {
+    const sanitizedElement = DOMPurify.sanitize(element, { RETURN_DOM: true });
+    if (sanitizedElement.tagName.toLowerCase() === 'body' && element.tagName.toLowerCase() !== 'body') {
+        return sanitizedElement.firstElementChild as HTMLElement;
+    }
+    return sanitizedElement;
 }

--- a/test-server/public/import4.css
+++ b/test-server/public/import4.css
@@ -1,0 +1,3 @@
+img.dangerous[onload="console.log('danger')"] {
+	content: 'image.png';
+}

--- a/tests/sanitize.spec.ts
+++ b/tests/sanitize.spec.ts
@@ -14,7 +14,7 @@ div.last[onclick="console.log('foo')"] {
 
 test('Sanitization Off', async ({ page }) => {
 	await page.goto('http://localhost:5173/');
-	const body = await page.evaluate(async (css1) => { document.body = await cssToHtml(css1, { imports: 'include', sanitize: 'off' }); return document.body.outerHTML; }, css);
+	const body = await page.evaluate(async (css) => { document.body = await cssToHtml(css, { imports: 'include', sanitize: 'off' }); return document.body.outerHTML; }, css);
 
 	// The body should have exactly two direct children.
 	const bodyDirectChildren = page.locator('body > *');
@@ -53,7 +53,7 @@ test('Sanitization Off', async ({ page }) => {
 
 test('Sanitize Imports Only', async ({ page }) => {
 	await page.goto('http://localhost:5173/');
-	const body = await page.evaluate(async (css1) => { document.body = await cssToHtml(css1, { imports: 'include', sanitize: 'imports' }); return document.body.outerHTML; }, css);
+	const body = await page.evaluate(async (css) => { document.body = await cssToHtml(css, { imports: 'include', sanitize: 'imports' }); return document.body.outerHTML; }, css);
 
 	// The body should have exactly two direct children.
 	const bodyDirectChildren = page.locator('body > *');
@@ -128,14 +128,14 @@ async function expectEverythingToBeSanitized (page: Page): Promise<void> {
 
 test('Sanitize Everything', async ({ page }) => {
 	await page.goto('http://localhost:5173/');
-	const body = await page.evaluate(async (css1) => { document.body = await cssToHtml(css1, { imports: 'include', sanitize: 'all' }); return document.body.outerHTML; }, css);
+	const body = await page.evaluate(async (css) => { document.body = await cssToHtml(css, { imports: 'include', sanitize: 'all' }); return document.body.outerHTML; }, css);
 
 	await expectEverythingToBeSanitized(page);
 });
 
 test('Sanitize Everything By Default', async ({ page }) => {
 	await page.goto('http://localhost:5173/');
-	const body = await page.evaluate(async (css1) => { document.body = await cssToHtml(css1, { imports: 'include' }); return document.body.outerHTML; }, css);
+	const body = await page.evaluate(async (css) => { document.body = await cssToHtml(css, { imports: 'include' }); return document.body.outerHTML; }, css);
 
 	await expectEverythingToBeSanitized(page);
 });

--- a/tests/sanitize.spec.ts
+++ b/tests/sanitize.spec.ts
@@ -1,0 +1,130 @@
+/*
+ * Verify that DOM sanitization is working.
+ */
+
+import { test, expect } from '@playwright/test';
+import { cssToHtml } from '../src/index';
+
+const css = `
+@import url('http://localhost:5173/import4.css');
+div.last[onclick="console.log('foo')"] {
+	content: 'A';
+}
+`;
+
+test('Sanitization Off', async ({ page }) => {
+	await page.goto('http://localhost:5173/');
+	const body = await page.evaluate(async (css1) => { document.body = await cssToHtml(css1, { imports: 'include', sanitize: 'off' }); return document.body.outerHTML; }, css);
+
+	// The body should have exactly two direct children.
+	const bodyDirectChildren = page.locator('body > *');
+	expect(await bodyDirectChildren.count()).toBe(2);
+
+	// The body's direct children should be in a specific order.
+	const last = page.locator('img:first-child + .last:last-child');
+	expect(await last.count()).toBe(1);
+	const lastElement = await last.elementHandle();
+	expect(lastElement).toBeTruthy();
+
+	// There should be exactly one img element.
+	const img = page.locator('img');
+	expect(await img.count()).toBe(1);
+	const imgElement = await img.elementHandle();
+	expect(imgElement).toBeTruthy();
+
+	// The img should have an `onload` attribute.
+	const imgAttribute = await imgElement?.getAttribute('onload');
+	expect(imgAttribute).toBe('console.log(\'danger\')');
+
+	// There should be exactly one div element.
+	const div = page.locator('div');
+	expect(await div.count()).toBe(1);
+	const divElement = await div.elementHandle();
+	expect(divElement).toBeTruthy();
+
+	// The div should have specific text content.
+	const divContent = await divElement?.innerHTML();
+	expect(divContent).toBe('A');
+
+	// The div should have an `onclick` attribute.
+	const divAttribute = await divElement?.getAttribute('onclick');
+	expect(divAttribute).toBe('console.log(\'foo\')');
+});
+
+test('Sanitize Imports Only', async ({ page }) => {
+	await page.goto('http://localhost:5173/');
+	const body = await page.evaluate(async (css1) => { document.body = await cssToHtml(css1, { imports: 'include', sanitize: 'imports' }); return document.body.outerHTML; }, css);
+
+	// The body should have exactly two direct children.
+	const bodyDirectChildren = page.locator('body > *');
+	expect(await bodyDirectChildren.count()).toBe(2);
+
+	// The body's direct children should be in a specific order.
+	const last = page.locator('img:first-child + .last:last-child');
+	expect(await last.count()).toBe(1);
+	const lastElement = await last.elementHandle();
+	expect(lastElement).toBeTruthy();
+
+	// There should be exactly one img element.
+	const img = page.locator('img');
+	expect(await img.count()).toBe(1);
+	const imgElement = await img.elementHandle();
+	expect(imgElement).toBeTruthy();
+
+	// The img should not have an `onload` attribute.
+	const imgAttribute = await imgElement?.getAttribute('onload');
+	expect(imgAttribute).not.toBeDefined();
+
+	// There should be exactly one div element.
+	const div = page.locator('div');
+	expect(await div.count()).toBe(1);
+	const divElement = await div.elementHandle();
+	expect(divElement).toBeTruthy();
+
+	// The div should have specific text content.
+	const divContent = await divElement?.innerHTML();
+	expect(divContent).toBe('A');
+
+	// The div should have an `onclick` attribute.
+	const divAttribute = await divElement?.getAttribute('onclick');
+	expect(divAttribute).toBe('console.log(\'foo\')');
+});
+
+test('Sanitize Everything', async ({ page }) => {
+	await page.goto('http://localhost:5173/');
+	const body = await page.evaluate(async (css1) => { document.body = await cssToHtml(css1, { imports: 'include', sanitize: 'all' }); return document.body.outerHTML; }, css);
+
+	// The body should have exactly two direct children.
+	const bodyDirectChildren = page.locator('body > *');
+	expect(await bodyDirectChildren.count()).toBe(2);
+
+	// The body's direct children should be in a specific order.
+	const last = page.locator('img:first-child + .last:last-child');
+	expect(await last.count()).toBe(1);
+	const lastElement = await last.elementHandle();
+	expect(lastElement).toBeTruthy();
+
+	// There should be exactly one img element.
+	const img = page.locator('img');
+	expect(await img.count()).toBe(1);
+	const imgElement = await img.elementHandle();
+	expect(imgElement).toBeTruthy();
+
+	// The img should not have an `onload` attribute.
+	const imgAttribute = await imgElement?.getAttribute('onload');
+	expect(imgAttribute).not.toBeDefined();
+
+	// There should be exactly one div element.
+	const div = page.locator('div');
+	expect(await div.count()).toBe(1);
+	const divElement = await div.elementHandle();
+	expect(divElement).toBeTruthy();
+
+	// The div should have specific text content.
+	const divContent = await divElement?.innerHTML();
+	expect(divContent).toBe('A');
+
+	// The div should not have an `onclick` attribute.
+	const divAttribute = await divElement?.getAttribute('onclick');
+	expect(divAttribute).not.toBeDefined();
+});

--- a/tests/sanitize.spec.ts
+++ b/tests/sanitize.spec.ts
@@ -2,6 +2,8 @@
  * Verify that DOM sanitization is working.
  */
 
+// TODO: Make these tests more comprehensive. They should cover a wider range of sanitization cases.
+
 import { test, expect, type Page } from '@playwright/test';
 import { cssToHtml } from '../src/index';
 

--- a/tests/selector.spec.ts
+++ b/tests/selector.spec.ts
@@ -22,7 +22,7 @@ nav input[type="text"].search[readonly] {
 }
 `;
 
-const html = `<body><div id="cat"></div><div class="mouse"><span class="flea"></span><i></i></div><nav><a id="logo" class="icon" href=""><img src="https://example.com/image2"></a><input class="search" type="text" readonly="" placeholder="Search"></nav></body>`;
+const html = `<body><div id="cat"></div><div class="mouse"><span class="flea"></span><i></i></div><nav><a href="" class="icon" id="logo"><img src="https://example.com/image2"></a><input placeholder="Search" readonly="" type="text" class="search"></nav></body>`;
 
 test('Selector', async ({ page }) => {
 	await page.goto('http://localhost:5173/');


### PR DESCRIPTION
The generated HTML output is now sanitized by default. This should lower the risk of any XSS vulnerabilities arising from use with user generated or copy-pasted CSS. For example, the following CSS:
```css
img[onload="console.log('foo')"] {
    content: 'malicious.png';
}

script {
    content: 'fetch("http://malicious.com/").then(() => alert(1));';
}
```

When un-sanitized will produce:
```html
<body>
    <img src="malicious.png" onload="console.log('foo')">
    <script>
        fetch("http://malicious.com/").then(() => alert(1));
    </script>
</body>
```

But when sanitized will instead produce:
```html
<body>
    <img src="malicious.png">
    <script></script>
</body>
```

If you're using CSS-to-HTML as part of a framework or build process, elements like this may actually be desired. For cases like this, a new option has been added to configure the sanitization behaviour:
| Option       | Values         | Description |
| :----------- | :------------- | :---------- |
| `sanitize`   | `all` *        | Sanitize the generated HTML using [DOMPurify](https://github.com/cure53/DOMPurify). |
|              | `imports`      | Only sanitize the HTML generated from imported stylesheets. |
|              | `off`          | Don't sanitize the generated HTML. |
