### PR TITLE
Support nested selectors

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,6 +17,7 @@ jobs:
           comma,
           ignored,
           import,
+          nested,
           nth-child,
           sanitize,
           selector

--- a/tests/nested.spec.ts
+++ b/tests/nested.spec.ts
@@ -1,0 +1,55 @@
+/*
+ * Verify that nested selectors will be parsed correctly.
+ */
+
+import { test, expect } from '@playwright/test';
+import { cssToHtml } from '../src/index';
+
+const css = `
+nav > a#logo.icon img {
+	content: 'https://example.com/image';
+}
+nav a#logo.icon {
+	border-radius: 5px;
+
+	& > img {
+		content: 'https://example.com/image2';
+		display: block;
+	}
+}
+nav {
+	input[type="text"].search[readonly] {
+		content: 'Search';
+	}
+}
+main {
+	content: 'A';
+
+	& section {
+		content: 'B';
+
+		.foo {
+			content: 'C';
+		}
+
+		& * {
+			content: 'D';
+		}
+	}
+
+	:is(aside) {
+		& > p {
+			content: 'E';
+		}
+	}
+}
+`;
+
+const html = `<body><nav><a href="" class="icon" id="logo"><img src="https://example.com/image2"></a><input placeholder="Search" readonly="" type="text" class="search"></nav><main>A<section>B</section><section class="foo">C</section></main></body>`;
+
+test('Nested', async ({ page }) => {
+	await page.goto('http://localhost:5173/');
+	const body = await page.evaluate(async (css) => { document.body = await cssToHtml(css); return document.body.outerHTML; }, css);
+
+	expect(body).toBe(html);
+});

--- a/tests/nested.spec.ts
+++ b/tests/nested.spec.ts
@@ -9,6 +9,35 @@ const css = `
 nav > a#logo.icon img {
 	content: 'https://example.com/image';
 }
+nav a#logo.icon > img {
+	content: 'https://example.com/image2';
+	display: block;
+}
+nav input[type="text"].search[readonly] {
+	content: 'Search';
+}
+
+main {
+	content: 'A';
+}
+main section {
+	content: 'B';
+}
+main section .foo {
+	content: 'C';
+}
+main section * {
+	content: 'D';
+}
+main section :is(aside) > p {
+	content: 'E';
+}
+`;
+
+const nestedCss = `
+nav > a#logo.icon img {
+	content: 'https://example.com/image';
+}
 nav a#logo.icon {
 	border-radius: 5px;
 
@@ -18,10 +47,11 @@ nav a#logo.icon {
 	}
 }
 nav {
-	input[type="text"].search[readonly] {
+	& input[type="text"].search[readonly] {
 		content: 'Search';
 	}
 }
+
 main {
 	content: 'A';
 
@@ -45,11 +75,13 @@ main {
 }
 `;
 
-const html = `<body><nav><a href="" class="icon" id="logo"><img src="https://example.com/image2"></a><input placeholder="Search" readonly="" type="text" class="search"></nav><main>A<section>B</section><section class="foo">C</section></main></body>`;
+const html = `<body><nav><a href="" class="icon" id="logo"><img src="https://example.com/image2"></a><input placeholder="Search" readonly="" type="text" class="search"></nav><main>A<section>B<div class="foo">C</div></section></main></body>`;
 
 test('Nested', async ({ page }) => {
 	await page.goto('http://localhost:5173/');
 	const body = await page.evaluate(async (css) => { document.body = await cssToHtml(css); return document.body.outerHTML; }, css);
+	const nestedBody = await page.evaluate(async (css) => { document.body = await cssToHtml(css); return document.body.outerHTML; }, nestedCss);
 
 	expect(body).toBe(html);
+	expect(nestedBody).toBe(html);
 });

--- a/tests/nested.spec.ts
+++ b/tests/nested.spec.ts
@@ -75,7 +75,7 @@ main {
 }
 `;
 
-const html = `<body><nav><a href="" class="icon" id="logo"><img src="https://example.com/image2"></a><input placeholder="Search" readonly="" type="text" class="search"></nav><main>A<section>B<div class="foo">C</div></section></main></body>`;
+const html = `<body><nav><a href="" class="icon" id="logo"><img src="https://example.com/image2"></a><input placeholder="Search" readonly="" type="text" class="search"></nav><main><section><div class="foo">C</div></section></main></body>`;
 
 test('Nested', async ({ page }) => {
 	await page.goto('http://localhost:5173/');


### PR DESCRIPTION
This PR adds support for the [CSS nesting module](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_nesting) and the [nesting selector](https://developer.mozilla.org/en-US/docs/Web/CSS/Nesting_selector).

For example, standard syntax:
```css
main {
    display: flex;
}
main section {
    content: 'A';
}
main .message:is(.warning) {
    color: orange;
}
```

Equivalent nested syntax:
```css
main {
    display: flex;

    & section {
        content: 'A';
    }

    .message:is(.warning) {
        color: orange;
    }
}
```

Both produce:
```html
<body>
    <main>
        <section>A</section>
    </main>
</body>
```